### PR TITLE
Add lower-version limit to diffusers module to avoid conflicts with recent software (including ComfyUI-Manager)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "comfyui-diffusers"
 description = "This extension enables the use of the diffuser pipeline in ComfyUI. It also includes nodes related to Stream Diffusion."
 version = "1.0.1"
 license = { file = "LICENSE" }
-dependencies = ["diffusers[torch]", "accelerate", "transformers", "safetensors", "omegaconf", "pytorch_lightning", "xformers", "git+https://github.com/cumulo-autumn/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]"]
+dependencies = ["diffusers[torch]>=0.29.0", "accelerate", "transformers", "safetensors", "omegaconf", "pytorch_lightning", "xformers", "git+https://github.com/cumulo-autumn/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]"]
 
 [project.urls]
 Repository = "https://github.com/Limitex/ComfyUI-Diffusers"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffusers[torch]
+diffusers[torch]>=0.29.0
 accelerate
 transformers 
 safetensors 


### PR DESCRIPTION
ComfyUI-Manager depends on huggingface_hub>=0.20, which is incompatible with diffusers versions before 0.29.0. This prevents other packages from breaking ComfyUI-Manager when installing ComfyUI-Diffusers.